### PR TITLE
fix hyper-parameter graph issue in retiarii experiment

### DIFF
--- a/ts/webui/src/static/interface.ts
+++ b/ts/webui/src/static/interface.ts
@@ -228,6 +228,10 @@ interface SearchItems {
     isChoice: boolean; // for parameters: type = choice and status also as choice type
 }
 
+interface RetiariiParameter {
+    _visual_hyper_params_: object; // retiarii experiment's parameter
+}
+
 export {
     TableObj,
     TableRecord,
@@ -253,5 +257,6 @@ export {
     SortInfo,
     AllExperimentList,
     Tensorboard,
-    SearchItems
+    SearchItems,
+    RetiariiParameter
 };

--- a/ts/webui/src/static/model/trial.ts
+++ b/ts/webui/src/static/model/trial.ts
@@ -7,7 +7,8 @@ import {
     Parameters,
     FinalType,
     MultipleAxes,
-    SingleAxis
+    SingleAxis,
+    RetiariiParameter
 } from '../interface';
 import {
     getFinal,
@@ -27,13 +28,14 @@ import {
  * @returns Parsed structured parameters and unexpected entries
  */
 function inferTrialParameters(
-    paramObj: object,
+    paramObj: RetiariiParameter,
     space: MultipleAxes,
     prefix: string = ''
 ): [Map<SingleAxis, any>, Map<string, any>] {
+    const latestedParamObj = '_visual_hyper_params_' in paramObj ? paramObj._visual_hyper_params_ : paramObj;
     const parameters = new Map<SingleAxis, any>();
     const unexpectedEntries = new Map<string, any>();
-    for (const [k, v] of Object.entries(paramObj)) {
+    for (const [k, v] of Object.entries(latestedParamObj)) {
         // prefix can be a good fallback when corresponding item is not found in namespace
         const axisKey = space.axes.get(k);
         if (prefix && k === '_name') continue;


### PR DESCRIPTION
### Description ###

For Retiarii experiment:

Search space 干净，普通型
Trial parameter 返回了复杂格式，真正的 parameter 在一个叫 `_visual_hyper_params_` 的 key下，

这样的情况导致 hyper-parameter 画出的图诡异，没有崩溃，但是图多了很多无意义轴

☆ 修过之后，nested search space 里如果第一层出现叫 `_visual_hyper_params_` 的 key，会只画这个 key 名下的键值对


### Checklist ###

  - [ ] test case
  - [x] no doc should be updated

### How to test ###

- test nested experiment hyper-parameter
- test retiarii experiment hyper-parameter
